### PR TITLE
[test] TDD 포인트 사용 기능 구현 REFACTOR

### DIFF
--- a/src/main/kotlin/io/hhplus/tdd/point/PointService.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/PointService.kt
@@ -2,6 +2,7 @@ package io.hhplus.tdd.point
 
 import io.hhplus.tdd.database.PointHistoryTable
 import io.hhplus.tdd.database.UserPointTable
+import io.hhplus.tdd.point.exception.ErrorCode
 import org.springframework.stereotype.Service
 
 @Service
@@ -45,7 +46,7 @@ class PointService(
     }
 
     fun use(userId: Long, amount: Long): UserPoint {
-        require(amount > 0) { ErrorCode.INVALID_USE_AMOUNT.message }
+        validateAmount(amount, ErrorCode.INVALID_USE_AMOUNT)
 
         val currentPoint = userPointTable.selectById(userId)
 
@@ -66,5 +67,9 @@ class PointService(
         )
 
         return updatedPoint
+    }
+
+    private fun validateAmount(amount: Long, errorCode: ErrorCode) {
+        require(amount > 0) { errorCode.message }
     }
 }

--- a/src/main/kotlin/io/hhplus/tdd/point/PointService.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/PointService.kt
@@ -52,7 +52,7 @@ class PointService(
 
         val newAmount = currentPoint.point - amount
 
-        require(newAmount >= 0) { "잔고가 부족합니다" }
+        require(newAmount >= 0) { ErrorCode.INSUFFICIENT_BALANCE.message }
 
         val updatedPoint = userPointTable.insertOrUpdate(
             id = userId,

--- a/src/main/kotlin/io/hhplus/tdd/point/exception/ErrorCode.kt
+++ b/src/main/kotlin/io/hhplus/tdd/point/exception/ErrorCode.kt
@@ -1,4 +1,4 @@
-package io.hhplus.tdd.point
+package io.hhplus.tdd.point.exception
 
 enum class ErrorCode(val message: String) {
     INVALID_CHARGE_AMOUNT("충전 금액은 1원 이상이어야 합니다"),

--- a/src/test/kotlin/io/hhplus/tdd/PointServiceTest.kt
+++ b/src/test/kotlin/io/hhplus/tdd/PointServiceTest.kt
@@ -2,7 +2,7 @@ package io.hhplus.tdd
 
 import io.hhplus.tdd.database.PointHistoryTable
 import io.hhplus.tdd.database.UserPointTable
-import io.hhplus.tdd.point.ErrorCode
+import io.hhplus.tdd.point.exception.ErrorCode
 import io.hhplus.tdd.point.PointService
 import io.hhplus.tdd.point.TransactionType
 import org.assertj.core.api.Assertions.assertThat


### PR DESCRIPTION
### **커밋 링크**
#### RED & GREEN & REFACTOR
[이전 PR 참고](https://github.com/kbyunghoon/point-tdd/pull/8)

#### 추가 REFACTOR
[에러코드 Enum 경로 변경 (7ba530a)](https://github.com/kbyunghoon/point-tdd/commit/7ba530ab18db0f1b0d5ec7c94b07149626d93878)
[포인트 사용 및 차감을 위한 별도 포인트 검증 메서드 추가 (fc61518)](https://github.com/kbyunghoon/point-tdd/commit/fc61518187700046f89d125e2adfce2f893afd07)
[잔고 부족에 대한 예외 처리 enum으로 변경 (d1236a8)](https://github.com/kbyunghoon/point-tdd/commit/d1236a8b317017c348a3807ad64f75d348a5f759)


---
### **리뷰 포인트(질문)**
- 리뷰 포인트 1: 테스트 케이스가 더 필요한 부분이 있는지 확인 부탁드립니다.
---
### **이번주 KPT 회고**
| 구분 | 내용 |
|------|------|
| **Keep (유지해야 할 점)** | - |
| **Problem (개선이 필요한 점)** | - |
| **Try (시도할 점)** | - |